### PR TITLE
GH actions index with scip-go

### DIFF
--- a/.github/workflows/lsif.yml
+++ b/.github/workflows/lsif.yml
@@ -8,7 +8,7 @@ jobs:
   lsif-go:
     if: github.repository == 'sourcegraph/deploy-sourcegraph'
     runs-on: ubuntu-latest
-    container: sourcegraph/lsif-go
+    container: sourcegraph/scip-go
     steps:
       - uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e # renovate: tag=v1
       - name: Generate LSIF data


### PR DESCRIPTION
Replace lsif code intel builds with scip in github actions

[_Created by Sourcegraph batch change `christine/GithubActions-updateSGTest`._](https://demo.sourcegraph.com/users/christine/batch-changes/GithubActions-updateSGTest)